### PR TITLE
Option to remove leading whitespaces from completion when appropriate

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
           "default": 2,
           "description": "When the estimated number of tokens exceeds the limit, binary search will be used to reduce the number of lines. This parameter controls the maximum number of binary search iterations."
         },
-        "fauxpilot.trimLeftWhitespace": {
+        "fauxpilot.trimLeadingWhitespace": {
           "type": "boolean",
           "default": false,
           "description": "Trim leading whitespaces from returned text if the prompt ends in whitespace or if there are multiple white spaces returned."

--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
           "type":"number",
           "default": 2,
           "description": "When the estimated number of tokens exceeds the limit, binary search will be used to reduce the number of lines. This parameter controls the maximum number of binary search iterations."
+        },
+        "fauxpilot.trimLeftWhitespace": {
+          "type": "boolean",
+          "default": false,
+          "description": "Trim leading whitespaces from returned text if the prompt ends in whitespace or if there are multiple white spaces returned."
         }
       }
     }

--- a/src/FauxpilotClient.ts
+++ b/src/FauxpilotClient.ts
@@ -28,6 +28,7 @@ export class FauxpilotClient {
     private trim1stLineBreak = false;
     private resendIfEmptyResponse = false;
     private fetchWithoutLineBreak = false;
+    private trimLeadingWhitespace = false;
 
     public version: string;
     
@@ -81,6 +82,7 @@ export class FauxpilotClient {
         this.reduceLineTryTimes = extConfig.get("reduceLineTryTimes", 2);
         this.trim1stLineBreak = extConfig.get("trim1stLineBreak", false);
         this.resendIfEmptyResponse = extConfig.get("resendIfEmptyResponse", false);
+        this.trimLeadingWhitespace = extConfig.get("trimLeadingWhitespace", false);
 
         this.log(`enabled = ${this.enabled}`);
         this.log(`baseUrl = ${this.baseUrl}`);
@@ -97,6 +99,7 @@ export class FauxpilotClient {
         this.log(`reduceLineTryTimes = ${this.reduceLineTryTimes}`);
         this.log(`trim1stLineBreak = ${this.trim1stLineBreak}`);
         this.log(`resendIfEmptyResponse = ${this.resendIfEmptyResponse}`);
+        this.log(`trimLeadingWhitespace = ${this.trimLeadingWhitespace}`);
 
         rebuildAccessBackendCache();
         this.log("reload config finish.");
@@ -198,6 +201,10 @@ export class FauxpilotClient {
 
     public set IsFetchWithoutLineBreak(value: boolean) {
         this.fetchWithoutLineBreak = value;
+    }
+
+    public get TrimLeadingWhitespace(): boolean {
+        return this.trimLeadingWhitespace;
     }
     
 }

--- a/src/FauxpilotCompletionProvider.ts
+++ b/src/FauxpilotCompletionProvider.ts
@@ -13,7 +13,6 @@ import { fetch } from './AccessBackend';
 
 export class FauxpilotCompletionProvider implements InlineCompletionItemProvider {
     cachedPrompts: Map<string, number> = new Map<string, number>();
-
     private requestStatus: string = "done";
     private statusBar: StatusBarItem;
     private extConfig: WorkspaceConfiguration;
@@ -152,7 +151,7 @@ export class FauxpilotCompletionProvider implements InlineCompletionItemProvider
             }
 
             fauxpilotClient.IsFetchWithoutLineBreak = false;
-            const result = this.toInlineCompletions(response, position);
+            const result = this.toInlineCompletions(response, position, promptStr);
             if (result.length == 0 && fauxpilotClient.IsFetchWithoutLineBreak) {
                 if (token.isCancellationRequested) {
                     fauxpilotClient.log('request cancelled.');
@@ -180,7 +179,7 @@ export class FauxpilotCompletionProvider implements InlineCompletionItemProvider
         return Array.from(this.cachedPrompts.values()).reduce((a, b) => Math.max(a, b));
     }
 
-    private toInlineCompletions(value: OpenAI.Completion, position: Position): InlineCompletionItem[] {
+    private toInlineCompletions(value: OpenAI.Completion, position: Position, promptStr: string): InlineCompletionItem[] {
         if (!value.choices) {
             return [];
         }
@@ -214,6 +213,16 @@ export class FauxpilotCompletionProvider implements InlineCompletionItemProvider
                     choice1Text = choice1Text.substring(lineIndex + 1);
                 }
             }
+        }
+
+        if (fauxpilotClient.TrimLeadingWhitespace) {
+            const trailingWhiteSpace = promptStr.endsWith(" ");
+            if (trailingWhiteSpace) {
+                // Remove all leading whitespace from choice1Text
+                choice1Text = choice1Text.trimStart();
+            }
+            // Remove all but one leading whitespace
+            choice1Text = choice1Text.replace(/^\s+/, ' ');
         }
 
         return [new InlineCompletionItem(choice1Text, new Range(position, position.translate(0, choice1Text.length)))];

--- a/src/FauxpilotCompletionProvider.ts
+++ b/src/FauxpilotCompletionProvider.ts
@@ -13,6 +13,7 @@ import { fetch } from './AccessBackend';
 
 export class FauxpilotCompletionProvider implements InlineCompletionItemProvider {
     cachedPrompts: Map<string, number> = new Map<string, number>();
+
     private requestStatus: string = "done";
     private statusBar: StatusBarItem;
     private extConfig: WorkspaceConfiguration;


### PR DESCRIPTION
This adds an option in the extension settings to remove erroneous leading white spaces from completion.

I found that oftentimes my completion will suggest multiple blank spaces at the start even when the "prompt" ends in a space
[my code]{completion}:

[for i in ]{  range(0, 101)}

which would result in awkward looking code 'for i in   range(0, 101)' (apparently github fixes my multiple spaces so my example looks dumb)

With this change, it will check if the prompt ended in a space, and if so trim all leading whitespace from the result

If the prompt didn't end in a space, it will force the result to only start with a single space

this MIGHT break some weird edge cases i'm not thinking of, hence it's an option to enable